### PR TITLE
Switch to OpenAI with litellm

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy to .env and add your OpenAI key
+OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ Create a virtual environment with `uv` and install dependencies:
 
 ```bash
 uv venv
-uv pip install --system google-adk fastapi "uvicorn[standard]"
+uv pip install --system google-adk fastapi "uvicorn[standard]" litellm python-dotenv
 ```
+
+Create a `.env` file based on `.env.example` and set your `OPENAI_API_KEY`.
 
 Run the server:
 

--- a/agents/root/agent.py
+++ b/agents/root/agent.py
@@ -1,6 +1,7 @@
 from google.adk.agents import LlmAgent
+from google.adk.models.lite_llm import LiteLlm
 
 root_agent = LlmAgent(
-    model="gemini-pro",
-    instruction="You are a helpful chat assistant. Reply concisely to the user's messages."
+    model=LiteLlm(model="gpt-3.5-turbo"),
+    instruction="You are a helpful chat assistant. Reply concisely to the user's messages.",
 )

--- a/backend.py
+++ b/backend.py
@@ -1,4 +1,7 @@
 from google.adk.cli.fast_api import get_fast_api_app
+from dotenv import load_dotenv
+
+load_dotenv()
 
 app = get_fast_api_app(agents_dir="agents", web=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,5 +8,6 @@ dependencies = [
     "google-adk",
     "fastapi",
     "uvicorn[standard]",
-    "litellm"
+    "litellm",
+    "python-dotenv"
 ]


### PR DESCRIPTION
## Summary
- use litellm to call OpenAI in the default agent
- load environment variables via python-dotenv
- document `.env` usage for OpenAI key
- add `python-dotenv` dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686afa861f508332bde419022f742507